### PR TITLE
Add Rake task for rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_power_hmc.gemspec
 gemspec
 
-gem "manageiq-style", "~> 1.3.1"
 gem "rake", "~> 12.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_power_hmc.gemspec
 gemspec
 
+gem "manageiq-style", "~> 1.3.1"
 gem "rake", "~> 12.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 require "bundler/gem_tasks"
+require 'rubocop/rake_task'
+
 task :default => :spec
+
+RuboCop::RakeTask.new

--- a/ibm_power_hmc.gemspec
+++ b/ibm_power_hmc.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rest-client", "~> 2.1"
+
+  spec.add_development_dependency "manageiq-style", "~> 1.3"
 end


### PR DESCRIPTION
With this we can manage `manageiq-style` and `rubocop` versions with bundler. To run rubocop use the rake task: `bundle exec rake rubocop`.