### PR TITLE
add groups

### DIFF
--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -197,6 +197,18 @@ module IbmPowerHmc
     end
 
     ##
+    # @!method groups
+    # Retrieve the list of groups defined on the HMC.
+    # A logical partition, a virtual I/O server or a managed system can be
+    # associated with multiple group tags.
+    # @return [Array<IbmPowerHmc::Group>] The list of groups.
+    def groups
+      method_url = "/rest/api/uom/Group"
+      response = request(:get, method_url)
+      FeedParser.new(response.body).objects(:Group)
+    end
+
+    ##
     # @!method virtual_switches(sys_uuid)
     # Retrieve the list of virtual switches from a specified managed system.
     # @param sys_uuid [String] The UUID of the managed system.

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -230,6 +230,10 @@ module IbmPowerHmc
       :vtpm_lpars => "AssociatedSystemSecurity/AvailableVirtualTrustedPlatformModulePartitions"
     }.freeze
 
+    def group_uuids
+      uuids_from_links("AssociatedGroups")
+    end
+
     def cpu_compat_modes
       xml.get_elements("AssociatedSystemProcessorConfiguration/SupportedPartitionProcessorCompatibilityModes").map do |elem|
         elem.text&.strip
@@ -293,6 +297,10 @@ module IbmPowerHmc
       uuid_from_href(href) unless href.nil?
     end
 
+    def group_uuids
+      uuids_from_links("AssociatedGroups")
+    end
+
     def net_adap_uuids
       uuids_from_links("ClientNetworkAdapters")
     end
@@ -345,6 +353,27 @@ module IbmPowerHmc
 
     def vfc_mappings
       collection_of("VirtualFibreChannelMappings", "VirtualFibreChannelMapping")
+    end
+  end
+
+  # Group information
+  class Group < AbstractRest
+    ATTRS = {
+      :name => "GroupName",
+      :description => "GroupDescription",
+      :color => "GroupColor"
+    }.freeze
+
+    def sys_uuids
+      uuids_from_links("AssociatedManagedSystems")
+    end
+
+    def lpar_uuids
+      uuids_from_links("AssociatedLogicalPartitions")
+    end
+
+    def vios_uuids
+      uuids_from_links("AssociatedVirtualIOServers")
     end
   end
 


### PR DESCRIPTION
an LPAR, a VIOS or a CEC can be associated with multiple groups.