### PR TITLE
Taking charge of 408 timeout error

### DIFF
--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -624,7 +624,7 @@ module IbmPowerHmc
 
         # Try to parse body as an HttpErrorResponse
         unless err.response.nil?
-          resp = Parser.new(err.response.body).object(:HttpErrorResponse)
+          resp = Parser.new(err.response.body).object(:HttpErrorResponse) rescue nil
           unless resp.nil?
             @uri = resp.uri
             @reason = resp.reason


### PR DESCRIPTION
Now we can get a correct message from a timeout error. 

Pull request dedicated to this issue : https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/issues/44


Before : 

```
hc.logon
Traceback (most recent call last):
       15: from bin/console:14:in `<main>'
       14: from (irb):2
       13: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:43:in `logon'
       12: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:654:in `request'
       11: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:671:in `rescue in request'
       10: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:671:in `new'
        9: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:627:in `initialize'
        8: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:627:in `new'
        7: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/parser.rb:11:in `initialize'
        6: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/parser.rb:11:in `new'
        5: from /home/padmin/.rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/document.rb:101:in `initialize'
        4: from /home/padmin/.rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/document.rb:448:in `build'
        3: from /home/padmin/.rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/parsers/treeparser.rb:23:in `parse'
        2: from /home/padmin/.rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/parsers/baseparser.rb:183:in `pull'
        1: from /home/padmin/.rvm/gems/ruby-2.7.2/gems/rexml-3.2.5/lib/rexml/parsers/baseparser.rb:385:in `pull_event'
REXML::ParseException (Declarations can only occur in the doctype declaration.)
Line: 1
Position: 91
Last 80 unconsumed characters:
<!doctype html public -//IETF//DTD HTML 2.0//EN> <html><head><title>Console Inter
2.7.2 :003 >

```

And now : 
```
hc.logon
Traceback (most recent call last):
        5: from bin/console:14:in `<main>'
        4: from (irb):2
        3: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:43:in `logon'
        2: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:654:in `request'
        1: from /home/padmin/Calliste/ibm_power_hmc_sdk_ruby/lib/ibm_power_hmc/connection.rb:671:in `rescue in request'
IbmPowerHmc::Connection::HttpError (msg="408 Request Timeout" status="408" reason="" uri=)

```