### PR TITLE
Add begin rescue for NameError on storage

### DIFF
--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -575,7 +575,11 @@ module IbmPowerHmc
       # Possible storage types are:
       # LogicalUnit, PhysicalVolume, VirtualDisk, VirtualOpticalMedia
       elem = xml.elements["Storage/*[1]"]
-      Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
+      begin
+        Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
+      rescue
+        nil
+      end
     end
 
     def device


### PR DESCRIPTION
To handle this issue : 
`uninitialized constant IbmPowerHmc::SharedFileSystemFile`