### PR TITLE
add SharedFileSystemFile class definition for VSCSI storage type (HMC v10)

### DIFF
--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -430,6 +430,15 @@ module IbmPowerHmc
     }.freeze
   end
 
+  # SharedFileSystemFile information
+  class SharedFileSystemFile < VirtualSCSIStorage
+    ATTRS = {
+      :name => "SharedFileSystemFileName",
+      :path => "SharedFileSystemFilePath",
+      :udid => "UniqueDeviceID"
+    }.freeze
+  end
+
   # Virtual Media Repository information
   class VirtualMediaRepository < AbstractNonRest
     ATTRS = {
@@ -573,7 +582,8 @@ module IbmPowerHmc
 
     def storage
       # Possible storage types are:
-      # LogicalUnit, PhysicalVolume, VirtualDisk, VirtualOpticalMedia
+      # LogicalUnit, PhysicalVolume, VirtualDisk, VirtualOpticalMedia,
+      # SharedFileSystemFile
       elem = xml.elements["Storage/*[1]"]
       begin
         Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
@@ -585,7 +595,8 @@ module IbmPowerHmc
     def device
       # Possible backing device types are:
       # LogicalVolumeVirtualTargetDevice, PhysicalVolumeVirtualTargetDevice,
-      # SharedStoragePoolLogicalUnitVirtualTargetDevice, VirtualOpticalTargetDevice
+      # SharedStoragePoolLogicalUnitVirtualTargetDevice, VirtualOpticalTargetDevice,
+      # SharedFileSystemFileVirtualTargetDevice
       elem = xml.elements["TargetDevice/*[1]"]
       begin
         Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
@@ -656,6 +667,9 @@ module IbmPowerHmc
       VirtualOpticalMedia.new(elem) unless elem.nil?
     end
   end
+
+  # SharedFileSystemFile backing device information
+  class SharedFileSystemFileVirtualTargetDevice < VirtualTargetDevice; end
 
   # VFC mapping information
   class VirtualFibreChannelMapping < AbstractNonRest

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -577,7 +577,7 @@ module IbmPowerHmc
       elem = xml.elements["Storage/*[1]"]
       begin
         Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
-      rescue
+      rescue NameError
         nil
       end
     end
@@ -587,7 +587,11 @@ module IbmPowerHmc
       # LogicalVolumeVirtualTargetDevice, PhysicalVolumeVirtualTargetDevice,
       # SharedStoragePoolLogicalUnitVirtualTargetDevice, VirtualOpticalTargetDevice
       elem = xml.elements["TargetDevice/*[1]"]
-      Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
+      begin
+        Module.const_get("IbmPowerHmc::#{elem.name}").new(elem) unless elem.nil?
+      rescue NameError
+        nil
+      end
     end
   end
 


### PR DESCRIPTION
See https://github.ibm.com/katamari/dev-issue-tracking/issues/26360.
`SharedFileSystemFile` is a new VSCSI storage type used for e.g. GPFS file mapping (not yet documented in https://www.ibm.com/docs/en/power10/000V-HMC?topic=management-virtual-scsi-mapping).

```
    <!--
        =====================================================
        =  imports for VirtualSCSIStorage
        =====================================================
    -->
    <xsd:include schemaLocation='../../uom/LogicalUnit.xsd'/>
    <xsd:include schemaLocation='../../uom/PhysicalVolume.xsd'/>
    <xsd:include schemaLocation='../../uom/VirtualDisk.xsd'/>
    <xsd:include schemaLocation='../../uom/VirtualOpticalMedia.xsd'/>
    <xsd:include schemaLocation='../../uom/SharedFileSystemFile.xsd'/>

    <!--
        =====================================================
        =  imports for VirtualTargetDevice
        =====================================================
    -->
    <xsd:include schemaLocation='../../uom/LogicalVolumeVirtualTargetDevice.xsd'/>
    <xsd:include schemaLocation='../../uom/PhysicalVolumeVirtualTargetDevice.xsd'/>
    <xsd:include schemaLocation='../../uom/SharedStoragePoolLogicalUnitVirtualTargetDevice.xsd'/>
    <xsd:include schemaLocation='../../uom/VirtualOpticalTargetDevice.xsd'/>
    <xsd:include schemaLocation='../../uom/SharedFileSystemFileVirtualTargetDevice.xsd'/>
```