### PR TITLE
make vioses method permissive by default

### DIFF
--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -161,15 +161,17 @@ module IbmPowerHmc
     end
 
     ##
-    # @!method vioses(sys_uuid = nil, search = {})
+    # @!method vioses(sys_uuid = nil, search = {}, permissive = true)
     # Retrieve the list of virtual I/O servers managed by the HMC.
     # @param sys_uuid [String] The UUID of the managed system.
     # @param search [Hash] The optional property name and value to match.
+    # @param permissive [Boolean] Skip virtual I/O servers that have error conditions.
     # @return [Array<IbmPowerHmc::VirtualIOServer>] The list of virtual I/O servers.
-    def vioses(sys_uuid = nil, search = {})
+    def vioses(sys_uuid = nil, search = {}, permissive = true)
       if sys_uuid.nil?
         method_url = "/rest/api/uom/VirtualIOServer"
         search.each { |key, value| method_url += "/search/(#{key}==#{value})" }
+        method_url += "?ignoreError=true" if permissive
       else
         method_url = "/rest/api/uom/ManagedSystem/#{sys_uuid}/VirtualIOServer"
       end


### PR DESCRIPTION
This silently skips VIOSes that have error conditions instead of failing the full REST request.
This is a problem if one VIOS has its vio_daemon down.
Without this change, the VIOSes in the MIQ inventory are never updated.

I'm not sure what is the best approach here:
1. Have the SDK set ignoreError=true by default (no change is required to the MIQ provider)
2. Have the possibility to set ignoreError=true with a parameter (set to false by default).

Option 2 would allow the provider to call the vioses method first (without ignoreError), log the error, and then call the method again with ignoreError set to true.