### PR TITLE
Provisioning LPARs from Templates

### DIFF
--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -441,6 +441,13 @@ module IbmPowerHmc
       job
     end
 
+    ##
+    # @!method template_check(template_uuid, target_sys_uuid, sync = true)
+    # Start Template Check job (first of three steps to deploy an LPAR from a Template).
+    # @param template_uuid [String] The UUID of the Template to deploy an LPAR from.
+    # @param target_sys_uuid [String] The UUID of the Managed System to deploy the LPAR on.
+    # @param sync [Boolean] Start the job and wait for its completion.
+    # @return [IbmPowerHmc::HmcJob] The HMC job.
     def template_check(template_uuid, target_sys_uuid, sync = true)
       # Need to include session token in payload so make sure we are logged in
       logon if @api_session_token.nil?
@@ -454,6 +461,13 @@ module IbmPowerHmc
       job
     end
 
+    ##
+    # @!method template_transform(draft_template_uuid, target_sys_uuid, sync = true)
+    # Start Template Transform job (second of three steps to deploy an LPAR from a Template).
+    # @param draft_template_uuid [String] The UUID of the Draft Template created by the Template Check job.
+    # @param target_sys_uuid [String] The UUID of the Managed System to deploy the LPAR on.
+    # @param sync [Boolean] Start the job and wait for its completion.
+    # @return [IbmPowerHmc::HmcJob] The HMC job.
     def template_transform(draft_template_uuid, target_sys_uuid, sync = true)
       # Need to include session token in payload so make sure we are logged in
       logon if @api_session_token.nil?
@@ -467,6 +481,13 @@ module IbmPowerHmc
       job
     end
 
+    ##
+    # @!method template_deploy(draft_template_uuid, target_sys_uuid, sync = true)
+    # Start Template Deploy job (last of three steps to deploy an LPAR from a Template).
+    # @param draft_template_uuid [String] The UUID of the Draft Template created by the Template Check job.
+    # @param target_sys_uuid [String] The UUID of the Managed System to deploy the LPAR on.
+    # @param sync [Boolean] Start the job and wait for its completion.
+    # @return [IbmPowerHmc::HmcJob] The HMC job.
     def template_deploy(draft_template_uuid, target_sys_uuid, sync = true)
       # Need to include session token in payload so make sure we are logged in
       logon if @api_session_token.nil?
@@ -481,6 +502,13 @@ module IbmPowerHmc
       job
     end
 
+    ##
+    # @!method template_provision(template_uuid, target_sys_uuid, changes)
+    # Deploy Logical Partition from a Template (performs Check, Transform and Deploy steps in a single method).
+    # @param template_uuid [String] The UUID of the Template to deploy an LPAR from.
+    # @param target_sys_uuid [String] The UUID of the Managed System to deploy the LPAR on.
+    # @param changes [Hash] Modifications to apply to the Template before deploying Logical Partition.
+    # @return [String] The UUID of the deployed Logical Partition.
     def template_provision(template_uuid, target_sys_uuid, changes)
       # Need to include session token in payload so make sure we are logged in
       logon if @api_session_token.nil?

--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -481,6 +481,15 @@ module IbmPowerHmc
       job
     end
 
+    def template_provision(template_uuid, target_sys_uuid, changes)
+      # Need to include session token in payload so make sure we are logged in
+      logon if @api_session_token.nil?
+      draft_uuid = template_check(template_uuid, target_sys_uuid).results["TEMPLATE_UUID"]
+      template_transform(draft_uuid, target_sys_uuid)
+      template_modify(draft_uuid, changes)
+      template_deploy(draft_uuid, target_sys_uuid).results["PartitionUuid"]
+    end
+
     ##
     # @!method template(template_uuid, changes)
     # modify_object_attributes wrapper for templates.

--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -398,9 +398,10 @@ module IbmPowerHmc
     ##
     # @!method templates
     # Retrieve the list of partition templates.
+    # @param draft [Boolean] Retrieve draft templates as well
     # @return [Array<IbmPowerHmc::PartitionTemplate>] The list of partition templates.
-    def templates
-      method_url = "/rest/api/templates/PartitionTemplate?detail=full"
+    def templates(draft = false)
+      method_url = "/rest/api/templates/PartitionTemplate?detail=full#{'&draft=false' unless draft}"
       response = request(:get, method_url)
       FeedParser.new(response.body).objects(:PartitionTemplate)
     end
@@ -435,6 +436,46 @@ module IbmPowerHmc
         "K_X_API_SESSION_MEMENTO" => @api_session_token
       }
       job = HmcJob.new(self, method_url, "Capture", "PartitionTemplate", params)
+      job.run if sync
+      job
+    end
+
+    def template_check(template_uuid, target_sys_uuid, sync = true)
+      # Need to include session token in payload so make sure we are logged in
+      logon if @api_session_token.nil?
+      method_url = "/rest/api/templates/PartitionTemplate/#{template_uuid}/do/check"
+      params = {
+        "TargetUuid"              => target_sys_uuid,
+        "K_X_API_SESSION_MEMENTO" => @api_session_token
+      }
+      job = HmcJob.new(self, method_url, "Check", "PartitionTemplate", params)
+      job.run if sync
+      job
+    end
+
+    def template_transform(draft_template_uuid, target_sys_uuid, sync = true)
+      # Need to include session token in payload so make sure we are logged in
+      logon if @api_session_token.nil?
+      method_url = "/rest/api/templates/PartitionTemplate/#{draft_template_uuid}/do/transform"
+      params = {
+        "TargetUuid"              => target_sys_uuid,
+        "K_X_API_SESSION_MEMENTO" => @api_session_token
+      }
+      job = HmcJob.new(self, method_url, "Transform", "PartitionTemplate", params)
+      job.run if sync
+      job
+    end
+
+    def template_deploy(draft_template_uuid, target_sys_uuid, sync = true)
+      # Need to include session token in payload so make sure we are logged in
+      logon if @api_session_token.nil?
+      method_url = "/rest/api/templates/PartitionTemplate/#{draft_template_uuid}/do/deploy"
+      params = {
+        "TargetUuid"              => target_sys_uuid,
+        "TemplateUuid"            => draft_template_uuid,
+        "K_X_API_SESSION_MEMENTO" => @api_session_token
+      }
+      job = HmcJob.new(self, method_url, "Deploy", "PartitionTemplate", params)
       job.run if sync
       job
     end

--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -388,9 +388,10 @@ module IbmPowerHmc
     ##
     # @!method templates_summary
     # Retrieve the list of partition template summaries.
+    # @param draft [Boolean] Retrieve draft templates as well
     # @return [Array<IbmPowerHmc::PartitionTemplateSummary>] The list of partition template summaries.
-    def templates_summary
-      method_url = "/rest/api/templates/PartitionTemplate"
+    def templates_summary(draft = false)
+      method_url = "/rest/api/templates/PartitionTemplate#{'?draft=false' unless draft}"
       response = request(:get, method_url)
       FeedParser.new(response.body).objects(:PartitionTemplateSummary)
     end

--- a/lib/ibm_power_hmc/job.rb
+++ b/lib/ibm_power_hmc/job.rb
@@ -52,7 +52,7 @@ module IbmPowerHmc
     end
 
     # @return [Hash] The job results returned by the HMC.
-    attr_reader :results
+    attr_reader :results, :last_status
 
     ##
     # @!method status
@@ -65,9 +65,9 @@ module IbmPowerHmc
         :content_type => "application/vnd.ibm.powervm.web+xml; type=JobRequest"
       }
       response = @conn.request(:get, @href, headers)
-      jobresp = Parser.new(response.body).object(:JobResponse)
-      @results = jobresp.results
-      jobresp.status
+      @last_status = Parser.new(response.body).object(:JobResponse)
+      @results = @last_status.results
+      @last_status.status
     end
 
     ##

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -915,9 +915,7 @@ module IbmPowerHmc
       REXML::XPath.match(xml, 'logicalPartitionConfig/virtualSCSIClientAdapters/VirtualSCSIClientAdapter').map do |adap|
         {
           :vios     => adap.elements['connectingPartitionName']&.text,
-          :lu       => adap.elements['associatedLogicalUnits/LogicalUnit/name']&.text,
           :physvol  => adap.elements['associatedPhysicalVolume/PhysicalVolume/name']&.text,
-          :vtd      => adap.elements['AssociatedTargetDevices/VirtualOpticalTargetDevice/name']&.text
         }
       end
     end
@@ -927,16 +925,12 @@ module IbmPowerHmc
       adaps.add_attribute('schemaVersion', 'V1_5_0')
       list.each do |vlan|
         adaps.add_element('VirtualSCSIClientAdapter', {'schemaVersion' => 'V1_5_0'}).tap do |v|
-          v.add_element('associatedLogicalUnits', {'schemaVersion' => 'V1_5_0'}).tap do |e|
-            e.add_element('LogicalUnit', {'schemaVersion' => 'V1_5_0'}).add_element('name').text = vlan[:lu] if vlan[:lu]
-          end
+          v.add_element('associatedLogicalUnits', {'schemaVersion' => 'V1_5_0'})
           v.add_element('associatedPhysicalVolume', {'schemaVersion' => 'V1_5_0'}).tap do |e|
             e.add_element('PhysicalVolume', {'schemaVersion' => 'V1_5_0'}).add_element('name').text = vlan[:physvol] if vlan[:physvol]
           end
           v.add_element('connectingPartitionName').text = vlan[:vios]
-          v.add_element('AssociatedTargetDevices', {'schemaVersion' => 'V1_5_0'}).tap do |e|
-            e.add_element('VirtualOpticalTargetDevice', {'schemaVersion' => 'V1_5_0'}).add_element('name').text = vlan[:vtd] if vlan[:vtd]
-          end
+          v.add_element('AssociatedTargetDevices', {'schemaVersion' => 'V1_5_0'})
           v.add_element('associatedVirtualOpticalMedia', {'schemaVersion' => 'V1_5_0'})
         end
       end
@@ -950,8 +944,8 @@ module IbmPowerHmc
     def vfc
       REXML::XPath.match(xml, 'logicalPartitionConfig/virtualFibreChannelClientAdapters/VirtualFibreChannelClientAdapter').map do |adap|
         {
-          :vios => adap.elements['connectingPartitionName'].text,
-          :port => adap.elements['portName'].text
+          :vios => adap.elements['connectingPartitionName']&.text,
+          :port => adap.elements['portName']&.text
         }
       end
     end
@@ -975,9 +969,9 @@ module IbmPowerHmc
     def vlans
       REXML::XPath.match(xml, 'logicalPartitionConfig/clientNetworkAdapters/ClientNetworkAdapter/clientVirtualNetworks/ClientVirtualNetwork').map do |vlan|
         {
-          :name    => vlan.elements['name'].text,
-          :vlan_id => vlan.elements['vlanId'].text,
-          :switch  => vlan.elements['associatedSwitchName'].text
+          :name    => vlan.elements['name']&.text,
+          :vlan_id => vlan.elements['vlanId']&.text,
+          :switch  => vlan.elements['associatedSwitchName']&.text
         }
       end
     end

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -910,6 +910,32 @@ module IbmPowerHmc
       :proc_units   => "logicalPartitionConfig/processorConfiguration/sharedProcessorConfiguration/desiredProcessingUnits",
       :procs        => "logicalPartitionConfig/processorConfiguration/dedicatedProcessorConfiguration/desiredProcessors"
     }.freeze
+
+    def vlans
+      REXML::XPath.match(xml, 'logicalPartitionConfig/clientNetworkAdapters/ClientNetworkAdapter/clientVirtualNetworks/ClientVirtualNetwork').map do |vlan|
+        {
+          :name    => vlan.elements['name'].text,
+          :vlan_id => vlan.elements['vlanId'].text,
+          :switch  => vlan.elements['associatedSwitchName'].text
+        }
+      end
+    end
+
+    def vlans=(list = [])
+      adaps = REXML::Element.new('clientNetworkAdapters')
+      adaps.add_attribute('schemaVersion', 'V1_5_0')
+      list.each do |vlan|
+        adaps.add_element('ClientNetworkAdapter',  {'schemaVersion' => 'V1_5_0'}).
+              add_element('clientVirtualNetworks', {'schemaVersion' => 'V1_5_0'}).
+              add_element('ClientVirtualNetwork',  {'schemaVersion' => 'V1_5_0'}).
+              tap do |v|
+          v.add_element('name').text                 = vlan[:name]
+          v.add_element('vlanId').text               = vlan[:vlan_id]
+          v.add_element('associatedSwitchName').text = vlan[:switch]
+        end
+      end
+      xml.elements['logicalPartitionConfig/clientNetworkAdapters'] = adaps
+    end
   end
 
   # HMC Event

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -937,9 +937,11 @@ module IbmPowerHmc
   # Job Response
   class JobResponse < AbstractRest
     ATTRS = {
-      :id      => "JobID",
-      :status  => "Status",
-      :message => "ResponseException/Message"
+      :id        => "JobID",
+      :status    => "Status",
+      :operation => "JobRequestInstance/RequestedOperation/OperationName",
+      :group     => "JobRequestInstance/RequestedOperation/GroupName",
+      :message   => "ResponseException/Message"
     }.freeze
 
     def results

--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -900,6 +900,8 @@ module IbmPowerHmc
     ATTRS = {
       :name         => "partitionTemplateName",
       :description  => "description",
+      :lpar_name    => "logicalPartitionConfig/partitionName",
+      :lpar_id      => "logicalPartitionConfig/partitionId",
       :os           => "logicalPartitionConfig/osVersion",
       :memory       => "logicalPartitionConfig/memoryConfiguration/currMemory",
       :dedicated    => "logicalPartitionConfig/processorConfiguration/hasDedicatedProcessors",


### PR DESCRIPTION
Add methods to deploy an LPAR from a Template.

Other changes:
 - Add a setter for attributes declared in ATTRS hash for AbstractNonRest objects
 - Raise an exception if a job's final status is not COMPLETED_OK