### PR TITLE
add ignoreError when CEC uuid is specified too

### DIFF
--- a/lib/ibm_power_hmc/connection.rb
+++ b/lib/ibm_power_hmc/connection.rb
@@ -171,10 +171,10 @@ module IbmPowerHmc
       if sys_uuid.nil?
         method_url = "/rest/api/uom/VirtualIOServer"
         search.each { |key, value| method_url += "/search/(#{key}==#{value})" }
-        method_url += "?ignoreError=true" if permissive
       else
         method_url = "/rest/api/uom/ManagedSystem/#{sys_uuid}/VirtualIOServer"
       end
+      method_url += "?ignoreError=true" if permissive
       response = request(:get, method_url)
       FeedParser.new(response.body).objects(:VirtualIOServer)
     end

--- a/lib/ibm_power_hmc/version.rb
+++ b/lib/ibm_power_hmc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IbmPowerHmc
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
In https://github.com/IBM/ibm_power_hmc_sdk_ruby/pull/72, `?ignoreError=true` was only set if no managed system uuid was passed to the vioses method. This is not what was intended.