### PR TITLE
fix VirtualIOAdapter lpar_id field

### DIFF
--- a/lib/ibm_power_hmc/parser.rb
+++ b/lib/ibm_power_hmc/parser.rb
@@ -518,7 +518,7 @@ module IbmPowerHmc
       :location => "LocationCode",
       :slot     => "VirtualSlotNumber",
       :required => "RequiredAdapter",
-      :lpar_id  => "LogicalPartitionID",
+      :lpar_id  => "LocalPartitionID",
       :dr_name  => "DynamicReconfigurationConnectorName"
     }.freeze
   end


### PR DESCRIPTION
Fixes https://github.com/IBM/ibm_power_hmc_sdk_ruby/pull/85 : `LogicalPartitionID` => `LocalPartitionID`