### PR TITLE
backout next_events changes

### DIFF
--- a/lib/ibm_power_hmc/version.rb
+++ b/lib/ibm_power_hmc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IbmPowerHmc
-  VERSION = "0.16.0"
+  VERSION = "0.16.1"
 end


### PR DESCRIPTION
Backout commit [9863a59cd51366196bcf9d693079c4543a112d31](https://github.com/IBM/ibm_power_hmc_sdk_ruby/commit/329a2c7a02b324c74ee388de88960a0f53968fd0)
After a while using the undocumented `Event?timeout=X` option the HMC will fail with:
```
REST026C Maximum number of event requests exceeded
```