### PR TITLE
fix network_adapter_lpar_create

### DIFF
--- a/lib/ibm_power_hmc/apis/uom.rb
+++ b/lib/ibm_power_hmc/apis/uom.rb
@@ -349,16 +349,19 @@ module IbmPowerHmc
     private :network_adapter
 
     ##
-    # @!method network_adapter_lpar_create(lpar_uuid, **args)
+    # @!method network_adapter_lpar_create(lpar_uuid, sys_uuid, vswitch_uuid, **args)
     # Create a virtual ethernet network adapter attached to a logical partition.
     # @param lpar_uuid [String] UUID of the logical partition.
+    # @param sys_uuid [String] UUID of the managed system of the virtual switch.
+    # @param vswitch_uuid [String] UUID of the virtual switch.
     # @param args [Hash] The network adapter properties.
     # @return [IbmPowerHmc::ClientNetworkAdapter] The created network adapter.
-    def network_adapter_lpar_create(lpar_uuid, **args)
+    def network_adapter_lpar_create(lpar_uuid, sys_uuid, vswitch_uuid, **args)
       method_url = "/rest/api/uom/LogicalPartition/#{lpar_uuid}/ClientNetworkAdapter"
       headers = {
         :content_type => "application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter"
       }
+      args[:vswitch_href] = "/rest/api/uom/ManagedSystem/#{sys_uuid}/VirtualSwitch/#{vswitch_uuid}"
       netadap = ClientNetworkAdapter.marshal(args)
       response = request(:put, method_url, headers, netadap.xml.to_s)
       Parser.new(response.body).object(:ClientNetworkAdapter)

--- a/lib/ibm_power_hmc/schema/uom.rb
+++ b/lib/ibm_power_hmc/schema/uom.rb
@@ -475,6 +475,10 @@ module IbmPowerHmc
     def vswitch_uuid
       uuids_from_links("AssociatedVirtualSwitch").first
     end
+
+    def vswitch_href=(href)
+      xml.add_element("AssociatedVirtualSwitch").add_element("link", "href" => href, "rel" => "related")
+    end
   end
 
   # Client Network Adapter information


### PR DESCRIPTION
When creating a client network adapter, the virtual switch cannot simply be set using `<VirtualSwitchID>` or `<VirtualSwitchName>` elements. It has to be set using `<AssociatedVirtualSwitch>` element.