### PR TITLE
Get SharedMemoryEnabled attribute for logical partitions

### DIFF
--- a/lib/ibm_power_hmc/schema/templates.rb
+++ b/lib/ibm_power_hmc/schema/templates.rb
@@ -16,6 +16,7 @@ module IbmPowerHmc
       :lpar_id      => "logicalPartitionConfig/partitionId",
       :os           => "logicalPartitionConfig/osVersion",
       :memory       => "logicalPartitionConfig/memoryConfiguration/currMemory",
+      :shared_mem   => "logicalPartitionConfig/memoryConfiguration/isSharedMemory",
       :dedicated    => "logicalPartitionConfig/processorConfiguration/hasDedicatedProcessors",
       :sharing_mode => "logicalPartitionConfig/processorConfiguration/sharingMode",
       :vprocs       => "logicalPartitionConfig/processorConfiguration/sharedProcessorConfiguration/desiredVirtualProcessors",

--- a/lib/ibm_power_hmc/schema/uom.rb
+++ b/lib/ibm_power_hmc/schema/uom.rb
@@ -135,6 +135,7 @@ module IbmPowerHmc
       :min_memory => "PartitionMemoryConfiguration/MinimumMemory",
       :max_memory => "PartitionMemoryConfiguration/MaximumMemory",
       :ams => "PartitionMemoryConfiguration/ActiveMemorySharingEnabled",
+      :shared_mem => "PartitionMemoryConfiguration/SharedMemoryEnabled",
       :dedicated => "PartitionProcessorConfiguration/CurrentHasDedicatedProcessors",
       :sharing_mode => "PartitionProcessorConfiguration/CurrentSharingMode",
       :uncapped_weight => "PartitionProcessorConfiguration/CurrentSharedProcessorConfiguration/CurrentUncappedWeight",


### PR DESCRIPTION
Set to true if partition uses the shared memory pool.