### PR TITLE
rexml 3.4.3 Document.new no longer accepts strings with no root element

### DIFF
--- a/lib/ibm_power_hmc/apis/connection.rb
+++ b/lib/ibm_power_hmc/apis/connection.rb
@@ -38,7 +38,7 @@ module IbmPowerHmc
       headers = {
         :content_type => "application/vnd.ibm.powervm.web+xml; type=LogonRequest"
       }
-      doc = REXML::Document.new("")
+      doc = REXML::Document.new(nil)
       doc.add_element("LogonRequest", "schemaVersion" => "V1_1_0")
       doc.root.add_namespace(WEB_XMLNS)
       doc.root.add_element("UserID").text = @username

--- a/lib/ibm_power_hmc/schema/parser.rb
+++ b/lib/ibm_power_hmc/schema/parser.rb
@@ -94,7 +94,7 @@ module IbmPowerHmc
     # @param namespace [String] The XML namespace to use.
     # @param version [String] The XML schema version to use.
     def self.marshal(attrs = {}, namespace = UOM_XMLNS, version = "V1_1_0")
-      doc = REXML::Document.new("")
+      doc = REXML::Document.new(nil)
       doc.add_element(name.split("::").last, "schemaVersion" => version)
       doc.root.add_namespace(namespace)
       obj = new(doc.root)


### PR DESCRIPTION
We generally create the xml document and add the root element and others afterwards. This is ok, but we need to call REXML::Document.new(nil) instead.  In 3.4.3 and future versions, it fails validation when the string provided to .new does not contain a root element.

See the discussion in: https://www.github.com/ruby/rexml/pull/291

We don't have tests for this sdk ruby gem but this demonstrates the suspect code in irb using rexml 3.4.3 and how .new(nil) can be used for the same behavior but in a way that wil work in 3.4.3 and in the future:

```ruby
irb(main):001> require 'rexml'
=> true
irb(main):002> REXML::VERSION
=> "3.4.3"
irb(main):003> doc = REXML::Document.new("")
/Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/baseparser.rb:271:in `pull_event': Malformed XML: No root element (REXML::ParseException)
Line: 0
Position: 0
Last 80 unconsumed characters:
...
...
...
irb(main):004> doc = REXML::Document.new(nil)
=> <UNDEFINED/>
irb(main):005> doc.add_element("LogonRequest", "schemaVersion" => "V1_1_0")
=> <LogonRequest schemaVersion='V1_1_0'/>
irb(main):007> doc.to_s
=> "<LogonRequest schemaVersion='V1_1_0'/>"
```