### PR TITLE
Fix unexpected end of input

### DIFF
--- a/lib/ibm_power_hmc/apis/uom.rb
+++ b/lib/ibm_power_hmc/apis/uom.rb
@@ -49,6 +49,7 @@ module IbmPowerHmc
     def managed_systems_quick
       method_url = "/rest/api/uom/ManagedSystem/quick/All"
       response = request(:get, method_url)
+      return [] if response.body.nil? || response.body.strip.empty?
       JSON.parse(response.body)
     end
 

--- a/lib/ibm_power_hmc/apis/uom.rb
+++ b/lib/ibm_power_hmc/apis/uom.rb
@@ -49,8 +49,7 @@ module IbmPowerHmc
     def managed_systems_quick
       method_url = "/rest/api/uom/ManagedSystem/quick/All"
       response = request(:get, method_url)
-      return [] if response.body.nil? || response.body.strip.empty?
-      JSON.parse(response.body)
+      JSONParser.new.parse(response.body)
     end
 
     ##
@@ -63,7 +62,7 @@ module IbmPowerHmc
       method_url = "/rest/api/uom/ManagedSystem/#{sys_uuid}/quick"
       method_url += "/#{property}" unless property.nil?
       response = request(:get, method_url)
-      JSON.parse(response.body)
+      JSONParser.new.parse(response.body)
     end
 
     ##
@@ -115,7 +114,7 @@ module IbmPowerHmc
         method_url = "/rest/api/uom/ManagedSystem/#{sys_uuid}/LogicalPartition/quick/All"
       end
       response = request(:get, method_url)
-      JSON.parse(response.body)
+      JSONParser.new.parse(response.body)
     end
 
     ##
@@ -236,7 +235,7 @@ module IbmPowerHmc
         method_url = "/rest/api/uom/ManagedSystem/#{sys_uuid}/VirtualIOServer/quick/All"
       end
       response = request(:get, method_url)
-      JSON.parse(response.body)
+      JSONParser.new.parse(response.body)
     end
 
     ##

--- a/lib/ibm_power_hmc/schema/parser.rb
+++ b/lib/ibm_power_hmc/schema/parser.rb
@@ -246,4 +246,12 @@ module IbmPowerHmc
       :message => "Message"
     }.freeze
   end
+
+  # JSON parser for handling JSON responses.
+  class JSONParser
+    def parse(body)
+      return [] if body.nil? || body.strip.empty?
+      JSON.parse(body)
+    end
+  end
 end


### PR DESCRIPTION
When a HMC with no hosts is connected to the ManageIQ, the refresh is failing with unexpected end of input. The same error is displayed in the UI.

<img width="745" height="483" alt="HMC_Provider_ManageIQ" src="https://github.com/user-attachments/assets/aa9be622-8c62-4bbd-83de-2a8c8c686374" />

After fixing the issue

<img width="1510" height="827" alt="After Fix" src="https://github.com/user-attachments/assets/e372a96d-a714-4ce0-b8c7-8d2d72fdbc34" />

@agrare @Fryguy Please review this.